### PR TITLE
Bring in Credentials Leakage Fix

### DIFF
--- a/browserup-proxy-core/src/main/java/com/browserup/bup/BrowserUpProxyServer.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/bup/BrowserUpProxyServer.java
@@ -376,7 +376,9 @@ public class BrowserUpProxyServer implements BrowserUpProxy {
                                 String chainedProxyAuth = chainedProxyCredentials;
                                 if (chainedProxyAuth != null) {
                                     if (httpObject instanceof HttpRequest) {
-                                        HttpHeaders.addHeader((HttpRequest)httpObject, HttpHeaderNames.PROXY_AUTHORIZATION, "Basic " + chainedProxyAuth);
+                                        if(ProxyUtils.isCONNECT(httpObject) || !((HttpRequest) httpObject).uri().startsWith("/")) {
+                                            HttpHeaders.addHeader((HttpRequest) httpObject, HttpHeaderNames.PROXY_AUTHORIZATION, "Basic " + chainedProxyAuth);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
This is a port of the BrowserMob PR here:

https://github.com/lightbody/browsermob-proxy/pull/756

@aliowka Have I captured your logic?  getUri was deprecated.