### PR TITLE
Add recognition of variant json content type strings

### DIFF
--- a/browserup-proxy-core/src/main/java/com/browserup/bup/util/BrowserUpHttpUtil.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/bup/util/BrowserUpHttpUtil.java
@@ -135,7 +135,7 @@ public class BrowserUpHttpUtil {
                 contentType.startsWith("application/json")  ||
                 contentType.startsWith("application/xml")  ||
                 contentType.startsWith("application/xhtml+xml") ||
-                contentType.startsWith("application/") && contentType.endsWith("+json")
+                (contentType.startsWith("application/") && contentType.endsWith("+json"))
                 );
     }
 

--- a/browserup-proxy-core/src/main/java/com/browserup/bup/util/BrowserUpHttpUtil.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/bup/util/BrowserUpHttpUtil.java
@@ -134,7 +134,8 @@ public class BrowserUpHttpUtil {
                 contentType.startsWith("application/javascript")  ||
                 contentType.startsWith("application/json")  ||
                 contentType.startsWith("application/xml")  ||
-                contentType.startsWith("application/xhtml+xml")
+                contentType.startsWith("application/xhtml+xml") ||
+                contentType.startsWith("application/") && contentType.endsWith("+json")
                 );
     }
 


### PR DESCRIPTION
This is a port of the PR found here:

https://github.com/lightbody/browsermob-proxy/pull/731

Note that we are not maintaining the legacy proxy server, so only the code for the littleproxy version was ported.