### PR TITLE
Add support for hitting chained proxy via HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ Sometimes you will want to route requests through an upstream proxy server. In t
     [~]$ curl -X POST http://localhost:8080/proxy?httpProxy=yourproxyserver.com:8080
     {"port":8081}
 
+If your upstream proxy server uses https, you can enable connecting using https like this:
+
+    [~]$ curl -X POST http://localhost:8080/proxy?httpProxy=yourproxyserver.com:8080&proxyHTTPS=true
+    {"port":8081}
+
+
 Alternatively, you can specify the upstream proxy config for all proxies created using the standard JVM [system properties for HTTP proxies](http://docs.oracle.com/javase/6/docs/technotes/guides/net/proxies.html).
 Note that you can still override the default upstream proxy via the POST payload, but if you omit the payload the JVM
 system properties will be used to specify the upstream proxy.

--- a/browserup-proxy-core/src/main/java/com/browserup/bup/BrowserUpProxy.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/bup/BrowserUpProxy.java
@@ -78,7 +78,7 @@ public interface BrowserUpProxy {
      * @throws java.lang.IllegalStateException if the proxy has not been started.
      */
     void stop();
-    
+
     /**
      * Like {@link #stop()}, shuts down the proxy server and no longer accepts incoming connections, but does not wait for any existing
      * network traffic to cease. Any existing connections to clients or to servers may be force-killed immediately.
@@ -563,6 +563,13 @@ public interface BrowserUpProxy {
      * @param chainedProxyAddress address of the upstream proxy
      */
     void setChainedProxy(InetSocketAddress chainedProxyAddress);
+
+    /**
+     * Instructs this proxy to route traffic through an upstream proxy using HTTPS.
+     *
+     * @param chainedProxyHTTPS address of the upstream proxy
+     */
+    void setChainedProxyHTTPS(boolean chainedProxyHTTPS);
 
     /**
      * Returns the address and port of the upstream proxy.

--- a/browserup-proxy-rest/src/main/java/com/browserup/bup/proxy/ProxyManager.java
+++ b/browserup-proxy-rest/src/main/java/com/browserup/bup/proxy/ProxyManager.java
@@ -133,7 +133,7 @@ public class ProxyManager {
         }
     }
 
-    public BrowserUpProxyServer create(String upstreamHttpProxy, String proxyUsername, String proxyPassword, Integer port, String bindAddr, String serverBindAddr, boolean useEcc, boolean trustAllServers) {
+    public BrowserUpProxyServer create(String upstreamHttpProxy, boolean upstreamProxyHttps, String proxyUsername, String proxyPassword, Integer port, String bindAddr, String serverBindAddr, boolean useEcc, boolean trustAllServers) {
         LOG.debug("Instantiate ProxyServer...");
         BrowserUpProxyServer proxy = new BrowserUpProxyServer();
 
@@ -161,6 +161,8 @@ public class ProxyManager {
                 LOG.error("Invalid upstream http proxy specified: " + upstreamHttpProxy + ". Must use host:port format.");
                 throw new RuntimeException("Invalid upstream http proxy");
             }
+
+            proxy.setChainedProxyHTTPS(upstreamProxyHttps);
         }
 
         InetAddress clientBindAddress = null;
@@ -204,23 +206,23 @@ public class ProxyManager {
     }
 
     public BrowserUpProxyServer create(String upstreamHttpProxy, String proxyUsername, String proxyPassword, Integer port, String bindAddr, boolean useEcc, boolean trustAllServers) {
-        return create(upstreamHttpProxy, proxyUsername, proxyPassword, port, null, null, false, false);
+        return create(upstreamHttpProxy, false, proxyUsername, proxyPassword, port, null, null, false, false);
     }
 
     public BrowserUpProxyServer create(String upstreamHttpProxy, String proxyUsername, String proxyPassword, Integer port) {
-        return create(upstreamHttpProxy, proxyUsername, proxyPassword, port, null, null, false, false);
+        return create(upstreamHttpProxy, false, proxyUsername, proxyPassword, port, null, null, false, false);
     }
 
     public BrowserUpProxyServer create(String upstreamHttpProxy, String proxyUsername, String proxyPassword) {
-        return create(upstreamHttpProxy, proxyUsername, proxyPassword, null, null, null, false, false);
+        return create(upstreamHttpProxy, false, proxyUsername, proxyPassword, null, null, null, false, false);
     }
 
     public BrowserUpProxyServer create() {
-        return create(null, null, null, null, null, null, false, false);
+        return create(null, false, null, null, null, null, null, false, false);
     }
 
     public BrowserUpProxyServer create(int port) {
-        return create(null, null, null, port, null, null, false, false);
+        return create(null, false,null , null, port, null, null, false, false);
     }
 
     public BrowserUpProxyServer get(int port) {

--- a/browserup-proxy-rest/src/main/java/com/browserup/bup/proxy/bricks/ProxyResource.java
+++ b/browserup-proxy-rest/src/main/java/com/browserup/bup/proxy/bricks/ProxyResource.java
@@ -76,6 +76,7 @@ public class ProxyResource {
         String httpProxy = request.param("httpProxy");
         String proxyUsername = request.param("proxyUsername");
         String proxyPassword = request.param("proxyPassword");
+        boolean upstreamProxyHttps = "true".equals(request.param("proxyHTTPS"));
 
         Hashtable<String, String> options = new Hashtable<String, String>();
 
@@ -101,7 +102,7 @@ public class ProxyResource {
                 paramBindAddr, paramPort, paramServerBindAddr);
         BrowserUpProxyServer proxy;
         try {
-            proxy = proxyManager.create(upstreamHttpProxy, proxyUsername, proxyPassword, paramPort, paramBindAddr, paramServerBindAddr, useEcc, trustAllServers);
+            proxy = proxyManager.create(upstreamHttpProxy, upstreamProxyHttps, proxyUsername, proxyPassword, paramPort, paramBindAddr, paramServerBindAddr, useEcc, trustAllServers);
         } catch (ProxyExistsException ex) {
             return Reply.with(new ProxyDescriptor(ex.getPort())).status(455).as(Json.class);
         } catch (ProxyPortsExhaustedException ex) {


### PR DESCRIPTION
Currently, browserup is not able to hit the upstream proxy via HTTPS, and will always send
requests to it using HTTP.

This change utilizes littleproxy's built in functionality to support hitting
the chained proxy using HTTPS.

As the chained proxy we set during the initial har proxy creation only has the hostname:port
combo instead of also the URL scheme, add a separate setting to enable HTTP vs HTTPS.