### PR TITLE
Update ResponseFilterAdapter.java

### DIFF
--- a/browserup-proxy-core/src/main/java/com/browserup/bup/filters/ResponseFilterAdapter.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/bup/filters/ResponseFilterAdapter.java
@@ -66,7 +66,7 @@ public class ResponseFilterAdapter extends HttpsAwareFiltersAdapter implements M
      * and sets a maximum response buffer size of 2 MiB.
      */
     public static class FilterSource extends HttpFiltersSourceAdapter {
-        private static final int DEFAULT_MAXIMUM_RESPONSE_BUFFER_SIZE = 2097152;
+        private static final int DEFAULT_MAXIMUM_RESPONSE_BUFFER_SIZE = 10485760;
 
         private final ResponseFilter filter;
         private final int maximumResponseBufferSizeInBytes;


### PR DESCRIPTION
Increased DEFAULT_MAXIMUM_RESPONSE_BUFFER_SIZE up to 10 MiB because the old value is really not sufficient for modern mobile applications.