### PR TITLE
Fix netty and littleproxy dependency scopes.

### DIFF
--- a/browserup-proxy-core/build.gradle
+++ b/browserup-proxy-core/build.gradle
@@ -57,6 +57,9 @@ uploadArchives {
 }
 
 dependencies {
+    api 'io.netty:netty-codec:4.1.42.Final'
+    api 'xyz.rogfam:littleproxy:2.0.0-beta-5'
+
     implementation project(':browserup-proxy-mitm')
 
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
@@ -69,7 +72,6 @@ dependencies {
         exclude(module: 'netty')
     }
     implementation 'dnsjava:dnsjava:2.1.9'
-    implementation 'io.netty:netty-all:4.1.42.Final'
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.63'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.63'
     implementation 'org.brotli:dec:0.1.2'
@@ -77,7 +79,6 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-api:3.141.59'
     implementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
-    implementation 'xyz.rogfam:littleproxy:2.0.0-beta-5'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.codehaus.groovy:groovy-all:2.5.8'

--- a/browserup-proxy-mitm/build.gradle
+++ b/browserup-proxy-mitm/build.gradle
@@ -57,16 +57,15 @@ uploadArchives {
 }
 
 dependencies {
-    api 'io.netty:netty-codec:4.1.42.Final'
-    api 'xyz.rogfam:littleproxy:2.0.0-beta-5'
-
     implementation 'com.google.guava:guava:28.1-jre'
 
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.63'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.63'
 
+    implementation 'io.netty:netty-codec:4.1.42.Final'
     implementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation 'xyz.rogfam:littleproxy:2.0.0-beta-5'
 
     testImplementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.9'
     testImplementation 'com.fasterxml.jackson.core:jackson-core:2.9.9'

--- a/browserup-proxy-mitm/build.gradle
+++ b/browserup-proxy-mitm/build.gradle
@@ -57,15 +57,16 @@ uploadArchives {
 }
 
 dependencies {
+    api 'io.netty:netty-codec:4.1.42.Final'
+    api 'xyz.rogfam:littleproxy:2.0.0-beta-5'
+
     implementation 'com.google.guava:guava:28.1-jre'
 
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.63'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.63'
 
-    implementation 'io.netty:netty-all:4.1.42.Final'
     implementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
-    implementation 'xyz.rogfam:littleproxy:2.0.0-beta-3'
 
     testImplementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.9'
     testImplementation 'com.fasterxml.jackson.core:jackson-core:2.9.9'

--- a/browserup-proxy-rest/build.gradle
+++ b/browserup-proxy-rest/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     implementation 'com.google.inject.extensions:guice-servlet:4.2.2'
     implementation 'com.google.inject.extensions:guice-multibindings:4.2.2'
     implementation 'com.google.sitebricks:sitebricks:0.8.11'
-    implementation 'io.netty:netty-all:4.1.42.Final'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
     implementation "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
@@ -100,6 +99,5 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.seleniumhq.selenium:selenium-api:3.4.0'
     testImplementation 'org.awaitility:awaitility:4.0.1'
-    testImplementation 'xyz.rogfam:littleproxy:2.0.0-beta-3'
     testImplementation 'com.github.tomakehurst:wiremock-jre8:2.24.1'
 }


### PR DESCRIPTION
Replace `netty-all` with `netty-codec` and place it with `littleproxy` to `api` dependency scope.

Closes #199