### PR TITLE
Support wildcard for Basic auth domains

### DIFF
--- a/browserup-proxy-core/src/main/java/com/browserup/bup/filters/AutoBasicAuthFilter.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/bup/filters/AutoBasicAuthFilter.java
@@ -47,7 +47,14 @@ public class AutoBasicAuthFilter extends HttpsAwareFiltersAdapter {
             String hostname = getHost(httpRequest);
 
             // if there is an entry in the credentials map matching this hostname, add the credentials to the request
-            String base64CredentialsForHostname = credentialsByHostname.get(hostname);
+            String base64CredentialsForHostname = null;
+            for (String key : credentialsByHostname.keySet()) {
+                String regex = key.replace("*", ".*?");
+                if (hostname.matches(regex)) {
+                    base64CredentialsForHostname = credentialsByHostname.get(key);
+                }
+            }
+
             if (base64CredentialsForHostname != null) {
                 httpRequest.headers().add(HttpHeaderNames.AUTHORIZATION, "Basic " + base64CredentialsForHostname);
             }


### PR DESCRIPTION
By merging this PR, the domain name for a basic auth setting allows wildcards (`*`). e.g. `*.example.com` matches `foobar.example.com`, `*` matches any hostname.

Note that I confirmed that this passes tests on the latest `master` branch but the jar file based on it doesn't work due to the #263. I confirmed the jar file generated based on 2.0.1 + changes in this PR works.