### PR TITLE
Adding bind address pre-check before starting the default proxy 

### DIFF
--- a/browserup-proxy-core/src/main/java/com/browserup/bup/BrowserUpProxyServer.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/bup/BrowserUpProxyServer.java
@@ -530,7 +530,7 @@ public class BrowserUpProxyServer implements BrowserUpProxy {
     @Override
     public int getPort() {
         if (started.get()) {
-            return proxyServer.getListenAddress().getPort();
+            return (proxyServer != null ?  proxyServer.getListenAddress().getPort() : 0);
         } else {
             return 0;
         }

--- a/browserup-proxy-rest/src/main/java/com/browserup/bup/exception/AddressInUseException.java
+++ b/browserup-proxy-rest/src/main/java/com/browserup/bup/exception/AddressInUseException.java
@@ -1,0 +1,46 @@
+/*
+ * Modifications Copyright (c) 2019 BrowserUp, Inc.
+ */
+
+package com.browserup.bup.exception;
+
+import java.net.InetAddress;
+
+public class AddressInUseException extends RuntimeException {
+
+	private static final long serialVersionUID = -2548760680049910435L;
+	private final int port;
+	private final InetAddress address;
+
+    public AddressInUseException(int port, InetAddress bindAddress) {
+        this.port = port;
+        this.address = bindAddress;
+    }
+
+    public AddressInUseException(String message, int port, InetAddress bindAddress) {
+        super(message);
+        this.port = port;
+        this.address = bindAddress;
+    }
+
+    public AddressInUseException(String message, Throwable cause, int port, InetAddress bindAddress) {
+        super(message, cause);
+        this.port = port;
+        this.address = bindAddress;
+    }
+
+    public AddressInUseException(Throwable cause, int port, InetAddress bindAddress) {
+        super(cause);
+        this.port = port;
+        this.address = bindAddress;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+	public InetAddress getAddress() {
+		return address;
+	}
+        
+}

--- a/browserup-proxy-rest/src/test/java/com/browserup/bup/proxy/ProxyPortAssignmentTest.java
+++ b/browserup-proxy-rest/src/test/java/com/browserup/bup/proxy/ProxyPortAssignmentTest.java
@@ -7,7 +7,12 @@ package com.browserup.bup.proxy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
 import com.browserup.bup.BrowserUpProxyServer;
+import com.browserup.bup.exception.AddressInUseException;
 import com.browserup.bup.exception.ProxyExistsException;
 import com.browserup.bup.exception.ProxyPortsExhaustedException;
 import com.browserup.bup.proxy.test.util.ProxyManagerTest;
@@ -56,5 +61,27 @@ public class ProxyPortAssignmentTest extends ProxyManagerTest {
             assertEquals(9094, e.getPort());
             proxyManager.delete(9094);
         }
+    }
+
+    @Test
+    public void testBindFailure() {
+    	
+    	int testPort = 9094;
+    	
+        InetSocketAddress testClientBindSocket = new InetSocketAddress(testPort);
+        
+        // Use a test socket to attempt binding with
+        try(Socket testSocket = new Socket()) {
+        	testSocket.bind(testClientBindSocket);	
+	        try{
+	            proxyManager.create(9094);
+	            fail();
+	        }catch(AddressInUseException e){
+	            assertEquals(9094, e.getPort());
+	        }
+        } catch (IOException e1) {
+			e1.printStackTrace();
+        	fail();
+		}
     }
 }


### PR DESCRIPTION
The LittleProxy code has a bug whereby when you try to bootstrap the proxy against a port that is already in use, it will fail and not cleanup it's resources. If left to run, this can eventually cause the max file descriptors to be reached.

We can't change LittleProxy but we can check to make sure port isn't already in use. In some environments it is not practical to assume the min-max ports will be reserved and unused all the time.