### PR TITLE
Fix unknown property distributionBaseName

### DIFF
--- a/browserup-proxy-dist/build.gradle
+++ b/browserup-proxy-dist/build.gradle
@@ -85,7 +85,7 @@ mainClassName = 'com.browserup.bup.proxy.Main'
 
 distributions {
     main {
-        distributionBaseName = 'browserup-proxy'
+        baseName = 'browserup-proxy'
         contents {
             from '../LICENSE'
             from '../README.md'
@@ -95,4 +95,3 @@ distributions {
         }
     }
 }
-


### PR DESCRIPTION
This seems to fix:

* What went wrong:
A problem occurred evaluating project ':browserup-proxy-dist'.
> Could not set unknown property 'distributionBaseName' for object of type org.gradle.api.distribution.internal.DefaultDistribution.

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating project ':browserup-proxy-dist'.
        at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:92)
        at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl$2.run(DefaultScriptPluginFactory.java:206)
        at org.gradle.configuration.ProjectScriptTarget.addConfiguration(ProjectScriptTarget.java:77)
        at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.apply(DefaultScriptPluginFactory.java:211)
        at org.gradle.configuration.BuildOperationScriptPlugin$1$1.run(BuildOperationScriptPlugin.java:69)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:402)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:394)

https://github.com/browserup/browserup-proxy/commit/54b6b36a0922e034a16dd13cc18ce4be24d80e7f