### PR TITLE
Make HarLog thread-safe

### DIFF
--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/model/HarLog.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/model/HarLog.java
@@ -5,11 +5,11 @@ import com.browserup.harreader.filter.HarEntriesUrlPatternFilter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -26,8 +26,8 @@ public class HarLog {
     private String version = DEFAULT_VERSION;
     private HarCreatorBrowser creator;
     private HarCreatorBrowser browser;
-    private List<HarPage> pages = new ArrayList<>();
-    private List<HarEntry> entries = new ArrayList<>();
+    private List<HarPage> pages = new CopyOnWriteArrayList<>();
+    private List<HarEntry> entries = new CopyOnWriteArrayList<>();
     private String comment;
 
     /**
@@ -75,7 +75,7 @@ public class HarLog {
      */
     public List<HarPage> getPages() {
         if (pages == null) {
-            pages = new ArrayList<>();
+            pages = new CopyOnWriteArrayList<>();
         }
         return pages;
     }
@@ -89,7 +89,7 @@ public class HarLog {
      */
     public List<HarEntry> getEntries() {
         if (entries == null) {
-            entries = new ArrayList<>();
+            entries = new CopyOnWriteArrayList<>();
         }
         return entries;
     }


### PR DESCRIPTION
The following exception is caused by concurrent read-write operations (proxy is adding new entries, while client is trying to read them):
```java
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1627)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at com.browserup.harreader.model.HarLog.findEntries(HarLog.java:178)
	at com.browserup.harreader.model.HarLog.findEntries(HarLog.java:172)
```

`browsermob-proxy` used `CopyOnWriteArrayList` which is thread-safe:
https://github.com/lightbody/browsermob-proxy/blob/master/browsermob-core/src/main/java/net/lightbody/bmp/core/har/HarLog.java#L13-L14

