### PR TITLE
Fix jetty issues--observed under openjdk12

### DIFF
--- a/browserup-proxy-core/build.gradle
+++ b/browserup-proxy-core/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation project(':browserup-proxy-mitm')
 
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation "org.eclipse.jetty:jetty-alpn-conscrypt-server:11.0.0"
 
     implementation 'org.awaitility:awaitility:4.0.2'
     implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
@@ -92,9 +93,10 @@ dependencies {
     testImplementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
     testImplementation "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
     testImplementation "org.eclipse.jetty:jetty-servlets:${jettyVersion}"
+
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
-    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.26.3'
+    testImplementation 'com.github.tomakehurst:wiremock-standalone:2.27.2'
     testImplementation 'org.mockito:mockito-core:3.6.28'
     testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'


### PR DESCRIPTION
Errors resolved in this PR:

* java.lang.IllegalStateException: No Server ALPNProcessors!

* After upgrade, got a no ClassDef for the wiremockmock for Jetty which the wiremock change fixed

Note: 

Still have these unrelated errors in com.browserup.bup.mitmproxy.NewHarTest:

org.junit.ComparisonFailure: Error in HAR response did not match expected DNS failure error message expected:<Unable to [resolve host: www.doesnotexist.address]> but was:<Unable to [connect to host]>
