### PR TITLE
urgent security fix: upgrade log4j to 2.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ subprojects {
         jacksonVersion = '2.12.0'
         javassistVersion = '3.27.0-GA'
         jettyVersion = '9.4.35.v20201120'
-        log4jVersion = '2.14.0'
+        log4jVersion = '2.15.0'
         nettyVersion = '4.1.55.Final'
         littleProxyVersion = '2.0.1'
         slf4jVersion = '1.7.30'


### PR DESCRIPTION
this fixes a 0-day exploit found in log4j2
see https://www.lunasec.io/docs/blog/log4j-zero-day/